### PR TITLE
Some optimisations

### DIFF
--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoContainer.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoContainer.groovy
@@ -67,16 +67,16 @@ class MojoContainer extends ModContainer {
                 .markerType(IModBusEvent)
                 .build()
 
-        this.activityMap[ModLoadingStage.CONSTRUCT] = this.&constructMojo
-        this.configHandler = Optional.of(this.&postConfigEvent as Consumer<IConfigEvent>)
-        this.contextExtension = { -> LOADING_CONTEXTS.computeIfAbsent(this, { this.buildMetaClass() }) } // Oh yes, lambdas...
+        this.activityMap[ModLoadingStage.CONSTRUCT] = this::constructMojo
+        this.configHandler = Optional.of(this::postConfigEvent as Consumer<IConfigEvent>)
+        this.contextExtension = () -> LOADING_CONTEXTS.computeIfAbsent(this, { this.buildMetaClass() }) // Oh yes, lambdas...
 
         try {
             def module = layer.findModule(info.owningFile.moduleName()).orElseThrow()
             this.mojoClass = Class.forName(module, className)
             LOGGER.trace(Logging.LOADING, 'Loaded class {} on class loader {}: time to get Groovy', this.mojoClass.name, this.mojoClass.classLoader)
         } catch (final Throwable t) {
-            LOGGER.fatal(Logging.LOADING, "An error occurred while attempting to load class ${ -> className }", t)
+            LOGGER.fatal(Logging.LOADING, "An error occurred while attempting to load class ${className}", t)
             throw new ModLoadingException(info, ModLoadingStage.CONSTRUCT, CLASS_ERROR, t)
         }
     }
@@ -98,7 +98,7 @@ class MojoContainer extends ModContainer {
             this.mojoBus.post(e)
             LOGGER.trace(Logging.LOADING, 'Fired event {} for mojo {}', e, this.modId)
         } catch (Throwable t) {
-            LOGGER.fatal(Logging.LOADING,"Caught exception in mojo '${ -> this.modId }' during event dispatch for ${ -> e }", t)
+            LOGGER.fatal(Logging.LOADING,"Caught exception in mojo '${this.modId}' during event dispatch for ${e}", t)
             throw new ModLoadingException(this.modInfo, this.modLoadingStage, EVENT_ERROR, t)
         }
     }
@@ -112,7 +112,7 @@ class MojoContainer extends ModContainer {
             this.mojo.metaClass = this.mojoClass.metaClass
             LOGGER.trace(Logging.LOADING, 'Successfully loaded mojo {} and injected metaclass', this.modId)
         } catch (final Throwable t) {
-            LOGGER.fatal(Logging.LOADING, "Failed to create mojo from class ${ -> this.mojoClass.name } for mojo ${ -> this.modId }", t)
+            LOGGER.fatal(Logging.LOADING, "Failed to create mojo from class ${this.mojoClass.name} for mojo ${this.modId}", t)
             throw new ModLoadingException(this.modInfo, ModLoadingStage.CONSTRUCT, MOD_ERROR, t, this.mojoClass)
         }
     }

--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoContainer.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoContainer.groovy
@@ -24,6 +24,7 @@
 
 package net.thesilkminer.mc.austinpowers
 
+import groovy.transform.CompileStatic
 import net.minecraftforge.eventbus.EventBusErrorMessage
 import net.minecraftforge.eventbus.api.BusBuilder
 import net.minecraftforge.eventbus.api.Event
@@ -41,6 +42,7 @@ import org.apache.logging.log4j.Logger
 
 import java.util.function.Consumer
 
+@CompileStatic
 class MojoContainer extends ModContainer {
     @SuppressWarnings('SpellCheckingInspection') private static final String CLASS_ERROR = 'fml.modloading.failedtoloadmodclass'
     @SuppressWarnings('SpellCheckingInspection') private static final String MOD_ERROR = 'fml.modloading.failedtoloadmod'

--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageLoader.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageLoader.groovy
@@ -82,11 +82,11 @@ class MojoLanguageLoader implements IModLanguageProvider.IModLanguageLoader {
             def mojoConstructor = mojoContainer.getConstructor(IModInfo, String, ModFileScanData, ModuleLayer)
             mojoConstructor.newInstance(info, this.className, modFileScanResults, layer) as T
         } catch (final InvocationTargetException e) {
-            LOGGER.fatal(Logging.LOADING, "A fatal error occurred while attempting to build mod ${ -> this.mojoId }", e)
+            LOGGER.fatal(Logging.LOADING, "A fatal error occurred while attempting to build mod ${this.mojoId}", e)
 
             throwModLoadingException('CONSTRUCT', e, LOADING_FAILED)
         } catch (NoSuchMethodException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            LOGGER.fatal(Logging.LOADING, "A fatal error has occurred while attempting to load the MojoContainer for mod ${ -> this.mojoId }", e)
+            LOGGER.fatal(Logging.LOADING, "A fatal error has occurred while attempting to load the MojoContainer for mod ${this.mojoId}", e)
 
             throwModLoadingException('CONSTRUCT', e, LOADING_FAILED)
         }

--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageLoader.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageLoader.groovy
@@ -24,6 +24,7 @@
 
 package net.thesilkminer.mc.austinpowers
 
+import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import net.minecraftforge.fml.Logging
 import net.minecraftforge.forgespi.language.IModInfo
@@ -92,6 +93,7 @@ class MojoLanguageLoader implements IModLanguageProvider.IModLanguageLoader {
         }
     }
 
+    @CompileStatic
     @Override
     String toString() {
         return "${this.mojoId}@${this.className}"

--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageProvider.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoLanguageProvider.groovy
@@ -24,6 +24,7 @@
 
 package net.thesilkminer.mc.austinpowers
 
+import groovy.transform.CompileStatic
 import net.minecraftforge.fml.Logging
 import net.minecraftforge.forgespi.language.IConfigurable
 import net.minecraftforge.forgespi.language.ILifecycleEvent
@@ -42,6 +43,7 @@ class MojoLanguageProvider implements IModLanguageProvider {
 
     private static final Logger LOGGER = LogManager.getLogger(MojoLanguageProvider)
 
+    @CompileStatic
     @Override
     String name() { NAME }
 

--- a/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoMetaClass.groovy
+++ b/src/main/groovy/net/thesilkminer/mc/austinpowers/MojoMetaClass.groovy
@@ -30,12 +30,12 @@ import groovy.transform.PackageScope
 class MojoMetaClass extends DelegatingMetaClass {
 
     private static final OVERRIDDEN_PROPERTIES = [
-            'mojoBus' : MojoMetaClass.&obtainMojoBus,
-            'forgeBus' : MojoMetaClass.&obtainForgeBus
+            'mojoBus' : MojoMetaClass::obtainMojoBus,
+            'forgeBus' : MojoMetaClass::obtainForgeBus
     ]
 
     private static final OVERRIDDEN_METHODS = [
-            'toString' : MojoMetaClass.&mojoToString
+            'toString' : MojoMetaClass::mojoToString
     ]
 
     private static final FORGE_BUS = {


### PR DESCRIPTION
Slightly smaller built jar, cleaner compiled output, slightly better performance, similar code.

- Replaced instances of `"thing is: ${ -> thing}"` with `"thing is: ${thing}"`
- ~~Replaced `this.&method` with `this::method` (the former creates a new closure iirc)~~ this only applies to CompileStatic, which is not in use for the code in question here
- Applied `@CompileStatic` to parts of the code that don't rely on any dynamic runtime features