### PR TITLE
Port to Forge 41.0.110, fixes #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ repositories {
 }
 
 dependencies {
-    minecraft group: 'net.minecraftforge', name: 'forge', version: "${mcVersion}-41.0.38"
+    minecraft group: 'net.minecraftforge', name: 'forge', version: "${mcVersion}-41.0.110"
     shade groovy('stdlib')
     shade groovy('ant')
     shade groovy('astbuilder')
@@ -435,6 +435,6 @@ testJar.dependsOn('reobfAllJar')
 build.dependsOn('testJar')
 
 wrapper {
-    gradleVersion = '7.4'
+    gradleVersion = '7.4.2'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/thesilkminer/mc/austin/boot/JarInJarLocatorVisitor.java
+++ b/src/main/java/net/thesilkminer/mc/austin/boot/JarInJarLocatorVisitor.java
@@ -55,7 +55,7 @@ final class JarInJarLocatorVisitor extends SimpleFileVisitor<Path> {
     }
 
     static Predicate<SecureJar> manifest(final Predicate<Manifest> manifestVerifier) {
-        return it -> manifestVerifier.test(it.getManifest());
+        return it -> manifestVerifier.test(it.moduleDataProvider().getManifest());
     }
 
     @Override

--- a/src/rtmod/groovy/net/thesilkminer/mc/austin/rt/AustinPowerfulMojo.groovy
+++ b/src/rtmod/groovy/net/thesilkminer/mc/austin/rt/AustinPowerfulMojo.groovy
@@ -24,9 +24,13 @@
 
 package net.thesilkminer.mc.austin.rt
 
+import groovy.transform.CompileStatic
+import groovy.transform.stc.POJO
 import net.thesilkminer.mc.austin.api.Mojo
 
-@Mojo("austin")
+@POJO
+@CompileStatic
+@Mojo('austin')
 class AustinPowerfulMojo {
     AustinPowerfulMojo() {}
 }

--- a/src/rtmod/resources/META-INF/mods.toml
+++ b/src/rtmod/resources/META-INF/mods.toml
@@ -12,7 +12,7 @@ description = "The Grooviest language provider in Forge!"
 [[dependencies.austin]]
 modId = "forge"
 mandatory = true
-versionRange = "[41,)"
+versionRange = "[41.0.110,)"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.austin]]

--- a/src/rtmod/resources/pack.mcmeta
+++ b/src/rtmod/resources/pack.mcmeta
@@ -1,6 +1,8 @@
 {
   "pack": {
-    "pack_format": 8,
-    "description": "Austin's Powerful Language Provider"
+    "description": "Austin's Powerful Language Provider",
+    "pack_format": 9,
+    "forge:resource_pack_format": 9,
+    "forge:data_pack_format": 10
   }
 }

--- a/src/test/resources/pack.mcmeta
+++ b/src/test/resources/pack.mcmeta
@@ -1,6 +1,8 @@
 {
     "pack": {
         "description": "Austin Powers' Language Provider: Keeping It Groovy Baby resources",
-        "pack_format": 8
+        "pack_format": 9,
+        "forge:resource_pack_format": 9,
+        "forge:data_pack_format": 10
     }
 }


### PR DESCRIPTION
- Update Forge base to 41.0.110 (latest at time of commit)
- Update Gradle from 7.4 to 7.4.2
- Update mods.toml and pack.mcmeta
- Fix SJH usage
- Made the rt mod POJO for a slightly smaller jar size